### PR TITLE
Support for arguments in the URL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,4 @@ v0.5.4, 2016-10-19 -- Prevent error for empty yaml file
 v1.0.0, 2017-08-01 -- Rename to canonicalwebteam.yaml-redirects; make use of canonicalwebteam.view-from-yaml
 v1.0.1, 2017-08-01 -- Fix dependencies in setup.py
 v1.0.2, 2017-08-01 -- Use views-from-yaml v0.2.2
+v1.0.4, 2017-11-22 -- Parse arguments from the request path into the target URL

--- a/canonicalwebteam/yaml_redirects/__init__.py
+++ b/canonicalwebteam/yaml_redirects/__init__.py
@@ -7,8 +7,8 @@ from django.shortcuts import redirect
 from canonicalwebteam.views_from_yaml import create_views_from_file
 
 
-def _redirect_to_target(request, target_url):
-    return redirect(target_url)
+def _redirect_to_target(request, target_url, *args, **kwargs):
+    return redirect(target_url.format(**kwargs))
 
 
 def create_views():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='canonicalwebteam.yaml-redirects',
-    version='1.0.2',
+    version='1.0.4',
     author='Canonical Webteam',
     url='https://github.com/canonical-webteam/yaml-redirects',
     packages=[
@@ -14,6 +14,6 @@ setup(
     ),
     install_requires=[
         "Django >= 1.3",
-        "canonicalwebteam.views-from-yaml >= 0.2.2",
+        "canonicalwebteam.views-from-yaml >= 0.2.3",
     ],
 )


### PR DESCRIPTION
Use the new version of views_from_yaml to pass any arguments in the request path match into the target URL.